### PR TITLE
Upgrade Parsec and improve performance

### DIFF
--- a/hsemail.cabal
+++ b/hsemail.cabal
@@ -34,9 +34,9 @@ library
     , parsec
     , mtl
   exposed-modules:
-      Text.ParserCombinators.Parsec.Rfc2234
-      Text.ParserCombinators.Parsec.Rfc2821
-      Text.ParserCombinators.Parsec.Rfc2822
+      Text.Parsec.Rfc2234
+      Text.Parsec.Rfc2821
+      Text.Parsec.Rfc2822
   other-modules:
       Paths_hsemail
   default-language: Haskell2010

--- a/src/Text/Parsec/Rfc2234.hs
+++ b/src/Text/Parsec/Rfc2234.hs
@@ -1,5 +1,6 @@
+{-# LANGUAGE FlexibleContexts #-}
 {- |
-   Module      :  Text.ParserCombinators.Parsec.Rfc2234
+   Module      :  Text.Parsec.Rfc2234
    Copyright   :  (c) 2013 Peter Simons
    License     :  BSD3
 
@@ -14,11 +15,12 @@
    here to avoid conflicts with Parsec's 'char' function.
  -}
 
-module Text.ParserCombinators.Parsec.Rfc2234 where
+module Text.Parsec.Rfc2234 where
 
-import Text.ParserCombinators.Parsec
+import Text.Parsec hiding (crlf)
+import qualified Text.Parsec.String as PS
 import Data.Char ( toUpper, chr, ord )
-import Control.Monad ( liftM2 )
+import Control.Monad ( liftM2, replicateM )
 
 -- Customize hlint ...
 {-# ANN module "HLint: ignore Use camelCase" #-}
@@ -29,35 +31,36 @@ import Control.Monad ( liftM2 )
 
 -- |Case-insensitive variant of Parsec's 'char' function.
 
-caseChar        :: Char -> CharParser st Char
+caseChar        :: Stream s m Char => Char -> ParsecT s u m Char
 caseChar c       = satisfy (\x -> toUpper x == toUpper c)
 
 -- |Case-insensitive variant of Parsec's 'string' function.
 
-caseString      :: String -> CharParser st ()
+caseString      :: Stream s m Char => String -> ParsecT s u m ()
 caseString cs    = mapM_ caseChar cs <?> cs
 
 -- |Match a parser at least @n@ times.
 
-manyN           :: Int -> GenParser a b c -> GenParser a b [c]
+-- manyN           :: Int -> GenParser a b c -> GenParser a b [c]
+manyN :: Int -> ParsecT s u m a -> ParsecT s u m [a]
 manyN n p
     | n <= 0     = return []
-    | otherwise  = liftM2 (++) (count n p) (many p)
+    | otherwise  = liftM2 (++) (replicateM n p) (many p)
 
 -- |Match a parser at least @n@ times, but no more than @m@ times.
 
-manyNtoM        :: Int -> Int -> GenParser a b c -> GenParser a b [c]
+manyNtoM        :: Int -> Int -> ParsecT s u m a -> ParsecT s u m [a]
 manyNtoM n m p
     | n < 0      = return []
     | n > m      = return []
-    | n == m     = count n p
-    | n == 0     = foldr (<|>) (return []) (map (\x -> try $ count x p) (reverse [1..m]))
-    | otherwise  = liftM2 (++) (count n p) (manyNtoM 0 (m-n) p)
+    | n == m     = replicateM n p
+    | n == 0     = foldr (<|>) (return []) (map (\x -> try $ replicateM x p) (reverse [1..m]))
+    | otherwise  = liftM2 (++) (replicateM n p) (manyNtoM 0 (m-n) p)
 
 -- |Helper function to generate 'Parser'-based instances for
 -- the 'Read' class.
 
-parsec2read :: Parser a -> String -> [(a, String)]
+parsec2read :: PS.Parser a -> String -> [(a, String)]
 parsec2read f x  = either (error . show) id (parse f' "" x)
   where
   f' = do { a <- f; res <- getInput; return [(a,res)] }
@@ -69,34 +72,34 @@ parsec2read f x  = either (error . show) id (parse f' "" x)
 
 -- |Match any character of the alphabet.
 
-alpha           :: CharParser st Char
+alpha           :: Stream s m Char => ParsecT s u m Char
 alpha            = satisfy (\c -> c `elem` (['A'..'Z'] ++ ['a'..'z']))
                    <?> "alphabetic character"
 
 -- |Match either \"1\" or \"0\".
 
-bit             :: CharParser st Char
+bit             :: Stream s m Char => ParsecT s u m Char
 bit              = oneOf "01"   <?> "bit ('0' or '1')"
 
 -- |Match any 7-bit US-ASCII character except for NUL (ASCII value 0, that is).
 
-character       :: CharParser st Char
+character       :: Stream s m Char => ParsecT s u m Char
 character        = satisfy (\c -> (c >= chr 1) && (c <= chr 127))
                    <?> "7-bit character excluding NUL"
 
 -- |Match the carriage return character @\\r@.
 
-cr              :: CharParser st Char
+cr              :: Stream s m Char => ParsecT s u m Char
 cr               = char '\r'    <?> "carriage return"
 
 -- |Match returns the linefeed character @\\n@.
 
-lf              :: CharParser st Char
+lf              :: Stream s m Char => ParsecT s u m Char
 lf               = char '\n'    <?> "linefeed"
 
 -- |Match the Internet newline @\\r\\n@.
 
-crlf            :: CharParser st String
+crlf            :: Stream s m Char => ParsecT s u m String
 crlf             = do c <- cr
                       l <- lf
                       return [c,l]
@@ -105,31 +108,31 @@ crlf             = do c <- cr
 -- |Match any US-ASCII control character. That is
 -- any character with a decimal value in the range of [0..31,127].
 
-ctl             :: CharParser st Char
+ctl             :: Stream s m Char => ParsecT s u m Char
 ctl              = satisfy (\c -> ord c `elem` ([0..31] ++ [127]))
                    <?> "control character"
 
 -- |Match the double quote character \"@\"@\".
 
-dquote          :: CharParser st Char
+dquote          :: Stream s m Char => ParsecT s u m Char
 dquote           = char (chr 34)    <?> "double quote"
 
 -- |Match any character that is valid in a hexadecimal number;
 -- [\'0\'..\'9\'] and [\'A\'..\'F\',\'a\'..\'f\'] that is.
 
-hexdig          :: CharParser st Char
+hexdig          :: Stream s m Char => ParsecT s u m Char
 hexdig           = hexDigit    <?> "hexadecimal digit"
 
 -- |Match the tab (\"@\\t@\") character.
 
-htab            :: CharParser st Char
+htab            :: Stream s m Char => ParsecT s u m Char
 htab             = char '\t'    <?> "horizontal tab"
 
 -- |Match \"linear white-space\". That is any number of consecutive
 -- 'wsp', optionally followed by a 'crlf' and (at least) one more
 -- 'wsp'.
 
-lwsp            :: CharParser st String
+lwsp            :: Stream s m Char => ParsecT s u m String
 lwsp             = do r <- choice
                            [ many1 wsp
                            , try (liftM2 (++) crlf (many1 wsp))
@@ -139,25 +142,25 @@ lwsp             = do r <- choice
                    <?> "linear white-space"
 
 -- |Match /any/ character.
-octet           :: CharParser st Char
+octet           :: Stream s m Char => ParsecT s u m Char
 octet            = anyChar    <?> "any 8-bit character"
 
 -- |Match the space.
 
-sp              :: CharParser st Char
+sp              :: Stream s m Char => ParsecT s u m Char
 sp               = char ' '    <?> "space"
 
 -- |Match any printable ASCII character. (The \"v\" stands for
 -- \"visible\".) That is any character in the decimal range of
 -- [33..126].
 
-vchar           :: CharParser st Char
+vchar           :: Stream s m Char => ParsecT s u m Char
 vchar            = satisfy (\c -> (c >= chr 33) && (c <= chr 126))
                    <?> "printable character"
 
 -- |Match either 'sp' or 'htab'.
 
-wsp             :: CharParser st Char
+wsp             :: Stream s m Char => ParsecT s u m Char
 wsp              = sp <|> htab    <?> "white-space"
 
 
@@ -166,7 +169,7 @@ wsp              = sp <|> htab    <?> "white-space"
 -- |Match a \"quoted pair\". Any characters (excluding CR and
 -- LF) may be quoted.
 
-quoted_pair     :: CharParser st String
+quoted_pair     :: Stream s m Char => ParsecT s u m String
 quoted_pair      = do _ <- char '\\'
                       r <- noneOf "\r\n"
                       return ['\\',r]
@@ -176,7 +179,7 @@ quoted_pair      = do _ <- char '\\'
 -- \"@\"@\" must be escaped inside a quoted string; CR and
 -- LF are not allowed at all.
 
-quoted_string   :: CharParser st String
+quoted_string   :: Stream s m Char => ParsecT s u m String
 quoted_string    = do _ <- dquote
                       r <- many qcont
                       _ <- dquote

--- a/src/Text/Parsec/Rfc2821.hs
+++ b/src/Text/Parsec/Rfc2821.hs
@@ -15,7 +15,6 @@
 
 module Text.Parsec.Rfc2821 where
 
-import Control.Monad.Identity
 import Control.Exception ( assert )
 import Control.Monad.State
 import Text.Parsec hiding (crlf)

--- a/src/Text/Parsec/Rfc2822.hs
+++ b/src/Text/Parsec/Rfc2822.hs
@@ -545,8 +545,7 @@ dtext           = no_ws_ctl
 -- represented in the 'Field' data type, and a message body, which may
 -- be empty.
 
-data GenericMessage a = Message [Field] a deriving Show
-type Message = GenericMessage String
+data GenericMessage a = Message [Field] (Maybe a) deriving Show
 
 -- |Parse a complete message as defined by this RFC and it broken down
 -- into the separate header fields and the message body. Header lines,
@@ -564,16 +563,15 @@ type Message = GenericMessage String
 -- the appropriate parser together yourself. You'll find that this is
 -- rather easy to do. Refer to the 'fields' parser for further details.
 
-message         :: Stream s m Char => ParsecT s u m Message
+message         :: Stream s m Char => ParsecT s u m (GenericMessage s)
 message         = do f <- fields
-                     b <- option [] (do _ <- crlf; body)
+                     b <- optionMaybe (do _ <- crlf; body)
                      return (Message f b)
 
 -- |A message body is just an unstructured sequence of characters.
 
-body            :: Stream s m Char => ParsecT s u m String
-body            = many anyChar
-
+body            :: Monad m => ParsecT s u m s
+body            = getInput
 
 -- * Field definitions (section 3.6)
 

--- a/test/spec.hs
+++ b/test/spec.hs
@@ -2,18 +2,19 @@ module Main ( main ) where
 
 import Test.Hspec
 import System.Time ( CalendarTime(..), Month(..), Day(..) )
-import Text.ParserCombinators.Parsec ( parse, eof, CharParser )
-import Text.ParserCombinators.Parsec.Rfc2822
+import Text.Parsec ( parse, eof )
+import Text.Parsec.String ( Parser )
+import Text.Parsec.Rfc2822
 
-parseTest :: CharParser () a -> String -> IO a
+parseTest :: Parser a -> String -> IO a
 parseTest p input = case parse (do { r <- p; eof; return r }) (show input) input of
                       Left err -> fail ("parse error at " ++ show err)
                       Right r -> return r
 
-parseIdemTest :: CharParser () String -> String -> Expectation
+parseIdemTest :: Parser String -> String -> Expectation
 parseIdemTest p input = parseTest p input `shouldReturn` input
 
-parseFailure :: (Show a) => CharParser () a -> String -> Expectation
+parseFailure :: (Show a) => Parser a -> String -> Expectation
 parseFailure p input = parse (do { r <- p; eof; return r }) (show input) input `shouldSatisfy` failure
   where
     failure (Left _) = True


### PR DESCRIPTION
- Fairly mechanical update to Parsec.
- Fixed a performance issue: `body` used to actually _parse_ the body, even though it was meant to just yield it, leading to bad performance when parsing, e.g., an email with a file attachment.